### PR TITLE
changing name field to op_name to fix KeyError

### DIFF
--- a/panther_detection_helpers/monitoring.py
+++ b/panther_detection_helpers/monitoring.py
@@ -26,7 +26,7 @@ def wrap(name: str, tags: Optional[Dict[Union[str, bytes], str]] = None) -> Call
     wrap is a function decorator to add metrics to a function and adds logging.
     If Datadog is not enabled, no metrics or logging is done.
     callers may use the @wrap decorator as follows:
-        @wrap(name="span_operation_name")
+        @wrap(name="operation_name")
         def my_function():
           ...
     """
@@ -42,7 +42,7 @@ def wrap(name: str, tags: Optional[Dict[Union[str, bytes], str]] = None) -> Call
         @functools.wraps(func)
         def func_wrapper(*args: Any, **kwargs: Any) -> Any:
             extras = {
-                "name": name,
+                "op_name": name,
                 "tags": tags,
             }
 


### PR DESCRIPTION
### Background

When using this lib, I was getting this error from running detections
```
KeyError("Attempt to overwrite 'name' in LogRecord")
```

It seems like it was coming from this chunk of code in the `logging` package used in PE
```
    def makeRecord(self, name, level, fn, lno, msg, args, exc_info,
                   func=None, extra=None, sinfo=None):
        """
        A factory method which can be overridden in subclasses to create
        specialized LogRecords.
        """
        rv = _logRecordFactory(name, level, fn, lno, msg, args, exc_info, func,
                             sinfo)
        if extra is not None:
            for key in extra:
                if (key in ["message", "asctime"]) or (key in rv.__dict__):
                    raise KeyError("Attempt to overwrite %r in LogRecord" % key)
                rv.__dict__[key] = extra[key]
        return rv
```

### References
<!-- relates to: app.asana.com/task_id # automation will link this PR to the Asana task -->
<!-- closes: app.asana.com/task_id # automation will close this Asana task -->

### Changes

* `name` -> `op_name`

### Testing

* Deployed this changed and the detection error went away
* I already wrote a unit test that checks to make sure nothing blows up when using monitoring so I am not sure why this didn't come up before
* I also used this module in my dev instance to test it and this didn't come up, not sure why this is coming up now
