### PR TITLE
new: added mocking module

### DIFF
--- a/panther_detection_helpers/mocking.py
+++ b/panther_detection_helpers/mocking.py
@@ -1,0 +1,10 @@
+from typing import Callable
+from unittest.mock import MagicMock
+
+
+def is_mock(func: Callable) -> bool:
+    """Checks if a callable 'func' is a Panther mock function or not."""
+    # We may one day use a different class for mocking, so to prevent customers from banking on the
+    # idea what we use MagicMock as a backend, we're performing this check in the private code of
+    # panther_detection_helpers, and not publicly in panther_analysis.
+    return isinstance(func, MagicMock)

--- a/tests/test_mocking.py
+++ b/tests/test_mocking.py
@@ -1,0 +1,14 @@
+import unittest
+from unittest.mock import MagicMock
+
+from panther_detection_helpers import mocking
+
+class TestMocking(unittest.TestCase):
+    def test_is_mock_true(self):
+        # Test using a fake mock function
+        func = MagicMock(return_value="string")
+        self.assertTrue(mocking.is_mock(func))
+
+    def test_is_mock_false(self):
+        # Test using a real function, like sum(x)
+        self.assertFalse(mocking.is_mock(sum))


### PR DESCRIPTION
New `mocking` module has a single function: `is_mock`. Also wrote some
unit tests for `is_mock`.

### Background

From a discussion about a new `unmock` helper function for Panther Analysis. We determined the code which checks if a function is a mock function is better to be here, since this is a private repo, and we don't want to encourage customers to rely on mocks always being an instance of `MagicMock`.

### References
* [Link to the previous discussion on my panther-analysis PR](https://github.com/panther-labs/panther-analysis/pull/919/files)

### Changes

* Created a new module (`mocking`)
* Created a function `is_mock`, which is passed a callable and returns `True` if the argument is a panther mock function
* Added a new test module for `mocking`, with 2 test functions for `is_mock`

### Testing

* Ran `make test` - no issues.
