### PR TITLE
Add force_ttl_check param to update in place functions

### DIFF
--- a/panther_detection_helpers/caching.py
+++ b/panther_detection_helpers/caching.py
@@ -412,22 +412,17 @@ def reset_string_set(key: str) -> None:
 
 
 @monitoring.wrap(name="panther_detection_helpers.caching.evaluate_threshold")
-def evaluate_threshold(
-    key: str, threshold: int = 10, expiry_seconds: int = 3600, force_ttl_check: bool = False
-) -> bool:
+def evaluate_threshold(key: str, threshold: int = 10, expiry_seconds: int = 3600) -> bool:
     """
     Increment counter and check whether the count meets the threshold. If so, reset and alert.
     Args:
         key: The name to evaluate
         threshold: (Optional) The threshold to meet or exceed. Default: 10
         expiry_seconds: (Optional) How many seconds from now to expire
-        force_ttl_check: (Optional) Whether to force a TTL check (rather than relying on underlying eventually-consistent mechanisms)
 
     Returns: Whether we met the threshold
     """
-    hourly_error_count = increment_counter(
-        key, force_ttl_check=force_ttl_check, epoch_seconds=expiry_seconds
-    )
+    hourly_error_count = increment_counter(key, epoch_seconds=expiry_seconds)
     # If it exceeds our threshold, reset and then return an alert
     if hourly_error_count >= threshold:
         reset_counter(key)
@@ -436,15 +431,14 @@ def evaluate_threshold(
 
 
 @monitoring.wrap(name="panther_detection_helpers.caching.check_account_age")
-def check_account_age(key: Any, force_ttl_check: bool = False) -> bool:
+def check_account_age(key: Any) -> bool:
     """
     Searches DynamoDB for stored user_id or account_id string stored by indicator creation
     rules for new user / account creation
 
     Args:
         key: The name to check
-        force_ttl_check: (Optional) Whether to force a TTL check (rather than relying on underlying eventually-consistent mechanisms)
     """
     if isinstance(key, str) and key != "":
-        return bool(get_string_set(key, force_ttl_check=force_ttl_check))
+        return bool(get_string_set(key, force_ttl_check=True))
     return False


### PR DESCRIPTION
### Background

Our caching modules let users write and update string sets and counters. They also let users specify a TTL for these counters and string sets. DynamoDB treats these TTLs as suggestions more so than laws, which causes issues for our customers using our caching modules and expecting TTLs to be applied quickly.

We added a `force_ttl_check` parameter to all our read / get functions to manually verify if TTL's have expired before returning the value. But our 'update in place' functions were missing this param, so a user might call `add_to_string_set` or `increment_counter` on an expired key and reasonably expect that the value would have been reset but that is not the case. This adds that.

### References
closes: https://app.asana.com/0/1200908948600035/1206376937072229/f

### Changes

* Add the `force_ttl_check` parameter to the two following functions
  * `evaluate_threshold` (calls `increment_counter`)
  * `check_account_age` (calls `get_string_set`)
* Updated the following three functions to force TTL checks in all cases
  * `increment_counter`
  * `add_to_string_set`
  * `remove_from_string_set`

### Testing

* `make fmt lint test`
* Loaded these into a normal global in pre-alpha and make sure they work as intended there, see [this](https://pre-alpha.runpanther.net/build/helpers/hakmiller_caching_overrides/edit/) and [this](https://pre-alpha.runpanther.net/build/detections/rules/HakmillerCachingTest/)
