### PR TITLE
adds release automation workflow

### DIFF
--- a/.github/workflows/test_release_publish.yml
+++ b/.github/workflows/test_release_publish.yml
@@ -1,0 +1,45 @@
+name: Build, Test, Publish Github and PyPI Releases
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish_github_release_and_pypi:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: Install pip and pipenv
+        run: |
+          python -m pip install --root-user-action=ignore --upgrade pip
+          pip install --root-user-action=ignore pipenv
+          pipenv install --dev
+
+      - name: Install Build and Test
+        run: |
+          make package
+
+      - name: Create Github Release
+        run: |
+          export NEW_VERSION=$(cat VERSION)
+          git config user.name "dac-bot"
+          git config user.email "dac-bot@panther.com"
+          gh release create v$NEW_VERSION dist/* -t v$NEW_VERSION --draft
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to PyPI
+        run: |
+          pipenv run twine upload dist/*
+        env:
+          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}


### PR DESCRIPTION
### Background
This adds similar release automation we have in place for panther-core and PAT. 

### References
<!-- relates to: app.asana.com/task_id # automation will link this PR to the Asana task -->
<!-- closes: app.asana.com/task_id # automation will close this Asana task -->

### Changes

* New workflow with same name we use in PAT/panther-core .. for creating a draft release and publishing to pypi

### Testing

* https://github.com/panther-labs/panther_detection_helpers/actions/runs/7836969216/job/21385706121
   * I feel pretty good about this since this is a lib similar to panther-core ... no need to release a new version as part of testing
      * failure here was only due to us trying to update the same version that is already released .. which is expected
