### PR TITLE
Setting KV store table name via env var

### DIFF
--- a/panther_detection_helpers/caching.py
+++ b/panther_detection_helpers/caching.py
@@ -36,8 +36,6 @@ def kv_table() -> boto3.resource:
             "dynamodb",
             endpoint_url="https://dynamodb" + FIPS_SUFFIX if FIPS_ENABLED else None,
         ).Table(os.getenv("KV_STORE_TABLE_NAME", "panther-kv-store"))
-    # FIXME
-    print("KV_TABLE: ", _KV_TABLE)
     return _KV_TABLE
 
 


### PR DESCRIPTION
### Background

Setting the KV table name via env var allows us to use a different table in different execution modes.

### References
https://panther-labs.atlassian.net/browse/DAC-700

### Changes

* Setting KV store table name via env var

### Testing

* Used KV store in replay, standard detections engine, verified that it works
