### PR TITLE
Use full Action SHAs rather than versioned releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  # Update the GitHub actions used in our CI/CD workflow
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "@panther-labs/admin"
+    assignees:
+      - "@panther-labs/admin"

--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -11,7 +11,7 @@ jobs:
     if: ${{ github.event.pull_request.state == 'open' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: panther-labs/github-asana-action@v3.0.7
+      - uses: panther-labs/github-asana-action@967374b16dafdcab025b073b2907aa4eaad11545
         name: Adds a comment to the related Asana task whenever a PR has been opened
         with:
           asana-pat: ${{ secrets.ASANA_PAT }}
@@ -19,7 +19,7 @@ jobs:
           text: ${{ format('A Pull Request has been opened {0}', github.event.pull_request.html_url) }}
           is-pinned: true
 
-      - uses: panther-labs/github-asana-action@v3.0.7
+      - uses: panther-labs/github-asana-action@967374b16dafdcab025b073b2907aa4eaad11545
         name: Moves the Asana task to "In Review" when the PR is opened
         with:
           asana-pat: ${{ secrets.ASANA_PAT }}
@@ -30,14 +30,14 @@ jobs:
     if: ${{ github.event.pull_request.state == 'closed' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: panther-labs/github-asana-action@v3.0.7
+      - uses: panther-labs/github-asana-action@967374b16dafdcab025b073b2907aa4eaad11545
         name: Adds a comment to the related Asana task when the PR is closed
         with:
           asana-pat: ${{ secrets.ASANA_PAT }}
           action: "add-comment"
           text: ${{ format('A Pull Request is now closed {0}', github.event.pull_request.html_url) }}
 
-      - uses: panther-labs/github-asana-action@v3.0.7
+      - uses: panther-labs/github-asana-action@967374b16dafdcab025b073b2907aa4eaad11545
         name: Closes the related Asana tasks when the PR gets merged
         if: github.event.pull_request.merged
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
       - name: Setup Python
-        uses: actions/setup-python@v4.3.0
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d
         with:
           python-version: 3.11
       - name: Install pipenv
@@ -29,11 +29,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
         with:
           token: ${{ secrets.PANTHER_BOT_AUTOMATION_TOKEN }}
       - name: Setup Python
-        uses: actions/setup-python@v4.3.0
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d
         with:
           python-version: 3.11
       - name: Install pipenv

--- a/.github/workflows/test_release_publish.yml
+++ b/.github/workflows/test_release_publish.yml
@@ -9,12 +9,12 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d
         with:
           python-version: '3.11'
 

--- a/.github/workflows/version_bump_pr.yml
+++ b/.github/workflows/version_bump_pr.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
### Background

Relates to: EPD-370

Pinning Action versions to the full SHA rather than the version is a best practice from a supply chain security perspective. Dependabot will handle any updates for us.

### Changes

* Moves all Actions to their latest respective commit SHA

### Testing

* Checks still pass as expected