### PR TITLE
Sign bot commits via gitsign

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
       - '*' # Match all branches
 
 permissions:
+  contents: write
   id-token: write
 
 jobs:


### PR DESCRIPTION
This PR uses Chainguard's setup-gitsign action to sign our fmt commits via Gitsign so that we can verify that panther-bot-automation did indeed make the change.

Trust, but verify!

Relates to: EPD-429