### PR TITLE
Skip dependabot PRs from FMT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
 
   fmt:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
### Background

FMT github action was failing for dependabot commits, as it has no access to org secrets.

### References
https://github.com/panther-labs/panther_detection_helpers/actions/runs/20924946392/job/60120174852?pr=51

### Changes
Skipping the FMT GHA if the actor of the PR is Dependabot.
